### PR TITLE
Fix for pop-up hidden by Gradia Capture extension when both are used

### DIFF
--- a/ocr.js
+++ b/ocr.js
@@ -537,10 +537,13 @@ export class ScreenshotOCRController {
             12,
             Math.min(global.stage.width - menuWidth - 12, Math.round(centerX - menuWidth / 2))
         );
-        const y = Math.max(
-            12,
-            Math.round(selection.y - menuHeight - 12)
-        );
+
+        // Place below the selection; fall back to above if no room below.
+        const belowY = Math.round(selection.y + selection.height + 12);
+        const aboveY = Math.round(selection.y - menuHeight - 12);
+        const y = belowY + menuHeight <= global.stage.height - 12
+            ? belowY
+            : Math.max(12, aboveY);
 
         this._copyMenu.set_position(x, y);
         this._copyMenu.visible = true;


### PR DESCRIPTION
## Before
<img width="600" height="382" alt="Kooha-2026-05-17-13-00-59 webm-00:00:04 328_2" src="https://github.com/user-attachments/assets/8883bb13-79c7-429e-8f93-830e10e60792" />


## After
<img width="600" height="382" alt="Kooha-2026-05-17-12-58-52 webm-00:00:07 254_2" src="https://github.com/user-attachments/assets/319441fc-5ed0-4f60-bf5a-1b778ca4c993" />
