### PR TITLE
use TESSDATA_PREFIX environment variable as TESSDATA_DIR

### DIFF
--- a/ocr.js
+++ b/ocr.js
@@ -27,7 +27,7 @@ const DEFAULT_OCR = {
     searchEngine: 'google',
     closeAfterCopy: false,
 };
-const TESSDATA_DIR = '/usr/share/tessdata';
+const TESSDATA_DIR = GLib.getenv('TESSDATA_PREFIX') || '/usr/share/tessdata';
 
 const OCRHighlightOverlay = GObject.registerClass(
 class OCRHighlightOverlay extends St.DrawingArea {

--- a/prefs.js
+++ b/prefs.js
@@ -16,7 +16,7 @@ const DEFAULTS = {
     'highlight-border-color': '0.92,0.94,0.97,0.34',
 };
 
-const TESSDATA_DIR = '/usr/share/tessdata';
+const TESSDATA_DIR = GLib.getenv('TESSDATA_PREFIX') || '/usr/share/tessdata';
 const DEFAULT_OCR_LANGUAGES = ['eng'];
 const HIDDEN_TESSERACT_LANGUAGES = new Set(['osd']);
 export default class ShotzyPreferences extends ExtensionPreferences {


### PR DESCRIPTION
I use nixos and the tesseract language data is installed in a folder other than /usr/share/tessdata Now you can use an environment variable to specify the location of tessdata.